### PR TITLE
fix: typo npm install 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env
 php artisan key:generate
 ```
 ```bash
-composer i
+npm i
 ```
 ```bash
 php artisan migrate


### PR DESCRIPTION
fix typo, harusnya `npm i` (install) bukan `composer i` lagi

![image](https://github.com/yandinovriandi/WMH/assets/50067865/ee033012-57eb-41b8-8c6a-0d3c9038228c)
